### PR TITLE
Comply with package name conventions

### DIFF
--- a/control_dsf_cd
+++ b/control_dsf_cd
@@ -1,4 +1,4 @@
-Package: ni-data-sharing-framework-custom-device-support-veristand-{veristand_version}
+Package: ni-data-sharing-framework-veristand-{veristand_version}-support
 Version: {nipkg_version}
 Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>


### PR DESCRIPTION
The NIPM convention is to use `<product>-<version>-support` as the end to a package name.
Our convention is to not put `custom-device` in the package name.