### PR TITLE
Modify export folder structure to match shipping structure

### DIFF
--- a/Core/Data Sharing Framework Core Build - Linux RT ARM.lvproj
+++ b/Core/Data Sharing Framework Core Build - Linux RT ARM.lvproj
@@ -148,18 +148,18 @@
 				<Property Name="Bld_modifyLibraryFile" Type="Bool">true</Property>
 				<Property Name="Bld_preActionVIID" Type="Ref">/My Computer/Build/Pre-Build Action (Linux RT).vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{27B26888-CB93-49ED-9A89-3C0D79B94D2A}</Property>
-				<Property Name="Bld_targetDestDir" Type="Path">../Built/Core/linux/arm</Property>
+				<Property Name="Bld_targetDestDir" Type="Path">../Built/Core/Linux_32_ARM</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">DSF Core.lvlibp</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Core/linux/arm/DSF Core.lvlibp</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Core/Linux_32_ARM/DSF Core.lvlibp</Property>
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Core/linux/arm</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Core/Linux_32_ARM</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{D70188A2-6E45-4CEA-99DF-BCCA42064DBE}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{959CD8F6-82C8-4D36-9535-16C62A4572D6}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux RT ARM/DSF Core.lvlib</Property>

--- a/Core/Data Sharing Framework Core Build - Linux RT.lvproj
+++ b/Core/Data Sharing Framework Core Build - Linux RT.lvproj
@@ -136,20 +136,20 @@
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_preActionVIID" Type="Ref">/My Computer/Build/Pre-Build Action (Linux RT).vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{559B0C74-4592-419C-B7EF-D9723B7D9E8B}</Property>
-				<Property Name="Bld_targetDestDir" Type="Path">../Built/Core/linux/x64</Property>
+				<Property Name="Bld_targetDestDir" Type="Path">../Built/Core/Linux_x64</Property>
 				<Property Name="Bld_version.build" Type="Int">2</Property>
 				<Property Name="Bld_version.minor" Type="Int">1</Property>
 				<Property Name="Bld_version.patch" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">DSF Core.lvlibp</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Core/linux/x64/DSF Core.lvlibp</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Core/Linux_x64/DSF Core.lvlibp</Property>
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Core/linux/x64/Support</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Core/Linux_x64/Support</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{C7A98361-5C43-4517-AB1E-F7A8FC7B6FF6}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{1FF87849-8A22-4175-B3EE-085D5AF03211}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux RT x64/DSF Core.lvlib</Property>

--- a/Core/Data Sharing Framework Core Build - PharLap x86.lvproj
+++ b/Core/Data Sharing Framework Core Build - PharLap x86.lvproj
@@ -134,20 +134,20 @@
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_preActionVIID" Type="Ref">/My Computer/Build/Pre-Build Action (Pharlap x86).vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{19113C8B-C1E1-4762-83FF-D3AEEA454CA5}</Property>
-				<Property Name="Bld_targetDestDir" Type="Path">../Built/Core/pharlap/x86</Property>
+				<Property Name="Bld_targetDestDir" Type="Path">../Built/Core/PharLap</Property>
 				<Property Name="Bld_version.build" Type="Int">2</Property>
 				<Property Name="Bld_version.minor" Type="Int">1</Property>
 				<Property Name="Bld_version.patch" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">DSF Core.lvlibp</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Core/pharlap/x86/DSF Core.lvlibp</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Core/PharLap/DSF Core.lvlibp</Property>
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Core/pharlap/x86/Support</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Core/PharLap/Support</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{3647B9A2-50AD-44E8-AD9D-259735EF2972}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{F98414A3-7960-4278-82C8-5841200CF5DB}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Pharlap x86/DSF Core.lvlib</Property>

--- a/Core/Data Sharing Framework Core Build - Windows.lvproj
+++ b/Core/Data Sharing Framework Core Build - Windows.lvproj
@@ -75,7 +75,7 @@
 			<Item Name="Data Sharing Framework Core" Type="Packed Library">
 				<Property Name="Bld_buildCacheID" Type="Str">{7DB90008-CD65-4A30-84EC-B7A2E16E7CDF}</Property>
 				<Property Name="Bld_buildSpecName" Type="Str">Data Sharing Framework Core</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Core/win/x86</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/Core/Windows</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_preActionVIID" Type="Ref">/My Computer/Build/Pre-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{52C1F69C-ADB0-4277-9DD9-A89D4CAD4397}</Property>
@@ -83,14 +83,14 @@
 				<Property Name="Bld_version.minor" Type="Int">1</Property>
 				<Property Name="Bld_version.patch" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">DSF Core.lvlibp</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Core/win/x86/DSF Core.lvlibp</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Core/Windows/DSF Core.lvlibp</Property>
 				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Core/win/x86/Support</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Core/Windows/Support</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="PackedLib_callersAdapt" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{48D75D8A-B30C-4140-905D-4F0236FD1DBC}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{479F5E7D-7E23-4C15-BC65-C73755B0CBB5}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/DSF Core.lvlib</Property>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2017', '2018', '2019', '2020']
+def lvVersions = ['2020']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)
 diffPipeline(lvVersions[0])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2020']
+def lvVersions = ['2017', '2018', '2019', '2020']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)
 diffPipeline(lvVersions[0])

--- a/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device Linux RT ARM.lvproj
+++ b/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device Linux RT ARM.lvproj
@@ -386,14 +386,14 @@
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{C6D45B23-7F5B-4C71-9DE9-20A1207D2007}</Property>
-				<Property Name="Bld_targetDestDir" Type="Path">../Built/Custom Device/linux/arm/DSF Engine Linux.llb</Property>
+				<Property Name="Bld_targetDestDir" Type="Path">../Built/Custom Device/Linux_32_ARM/DSF Engine Linux.llb</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/linux/arm/DSF Engine Linux.llb</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/Linux_32_ARM/DSF Engine Linux.llb</Property>
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/linux/arm</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/Linux_32_ARM</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="Source[0].Container.applyDestination" Type="Bool">true</Property>

--- a/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device Linux RT x64.lvproj
+++ b/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device Linux RT x64.lvproj
@@ -712,14 +712,14 @@
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{F44280A2-8E8C-42F2-A687-C3240BE4FC9A}</Property>
-				<Property Name="Bld_targetDestDir" Type="Path">../Built/Custom Device/linux/x64/DSF Engine Linux.llb</Property>
+				<Property Name="Bld_targetDestDir" Type="Path">../Built/Custom Device/Linux_x64/DSF Engine Linux.llb</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/linux/x64/DSF Engine Linux.llb</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/Linux_x64/DSF Engine Linux.llb</Property>
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/linux/x64</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/Linux_x64</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="Source[0].Container.applyDestination" Type="Bool">true</Property>

--- a/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device Pharlap.lvproj
+++ b/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device Pharlap.lvproj
@@ -414,19 +414,19 @@ AddOutputFilter chunkFilter
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{4E90626A-6DF7-4621-A062-A4F452B6E581}</Property>
-				<Property Name="Bld_targetDestDir" Type="Path">../Built/Custom Device/pharlap/x86/DSF Engine Pharlap.llb</Property>
+				<Property Name="Bld_targetDestDir" Type="Path">../Built/Custom Device/PharLap/DSF Engine Pharlap.llb</Property>
 				<Property Name="Bld_version.build" Type="Int">32</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/pharlap/x86/DSF Engine Pharlap.llb</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/PharLap/DSF Engine Pharlap.llb</Property>
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/pharlap/x86</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/PharLap</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="Source[0].Container.applyDestination" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{93F06B9C-09DC-488C-A7CE-964F98AA1316}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{10C24E39-C9F6-463D-8940-B7BA62811026}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/RT PXI Target/DSF Engine.lvlib/RT Driver VI.vi</Property>

--- a/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device.lvproj
+++ b/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device.lvproj
@@ -397,22 +397,23 @@
 			<Item Name="Configuration Release" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{F7E936A1-C50B-4217-AC2B-A4DA3629CD4B}</Property>
 				<Property Name="Bld_buildSpecName" Type="Str">Configuration Release</Property>
+				<Property Name="Bld_excludeDependentPPLs" Type="Bool">true</Property>
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device/win/x86</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{E8035317-FDF9-4FC1-9EF0-1450E8CAE472}</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/win/x86</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/win/x86</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device</Property>
 				<Property Name="Destination[2].destName" Type="Str">DSF Configuration LLB</Property>
-				<Property Name="Destination[2].path" Type="Path">../Built/Custom Device/win/x86/DSF Configuration.llb</Property>
+				<Property Name="Destination[2].path" Type="Path">../Built/Custom Device/DSF Configuration.llb</Property>
 				<Property Name="Destination[2].type" Type="Str">LLB</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
-				<Property Name="Source[0].itemID" Type="Str">{585C6FE3-3EF5-4D4B-B0A8-6F584E0952FD}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{FF5D026F-FC30-4B37-8D3F-3B389BA402E2}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Custom Device Data Sharing Framework.xml</Property>
@@ -455,18 +456,18 @@
 				<Property Name="Bld_buildSpecName" Type="Str">Engine Release</Property>
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device/win/x86/DSF Engine Windows.llb</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device/Windows/DSF Engine Windows.llb</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{32214451-43E2-4D3E-92C8-CE819321FAC4}</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/win/x86/DSF Engine Windows.llb</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/Windows/DSF Engine Windows.llb</Property>
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/win/x86</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/Windows</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{585C6FE3-3EF5-4D4B-B0A8-6F584E0952FD}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{FF5D026F-FC30-4B37-8D3F-3B389BA402E2}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/DSF Engine.lvlib/RT Driver VI.vi</Property>

--- a/build.toml
+++ b/build.toml
@@ -30,19 +30,19 @@ path = 'VeriStand\Data Sharing Custom Device\Source\Data Sharing Framework Custo
 [projects.CD_linuxRT_x64]
 path = 'VeriStand\Data Sharing Custom Device\Source\Data Sharing Framework Custom Device Linux RT x64.lvproj'
 
-[[build.steps]]
-name = 'Data Sharing Framework Core - Windows'
-type = 'lvBuildSpec'
-project = '{Core_windows}'
-target = 'My Computer'
-build_spec = 'Data Sharing Framework Core'
-
 #[[build.steps]]
-#name = 'Data Sharing Framework Core - Pharlap x86'
+#name = 'Data Sharing Framework Core - Windows'
 #type = 'lvBuildSpec'
-#project = '{Core_pharlap}'
-#target = 'Pharlap x86'
+#project = '{Core_windows}'
+#target = 'My Computer'
 #build_spec = 'Data Sharing Framework Core'
+
+[[build.steps]]
+name = 'Data Sharing Framework Core - Pharlap x86'
+type = 'lvBuildSpec'
+project = '{Core_pharlap}'
+target = 'Pharlap x86'
+build_spec = 'Data Sharing Framework Core'
 
 #[[build.steps]]
 #name = 'Data Sharing Framework Core - Linux RT ARM'
@@ -58,29 +58,29 @@ build_spec = 'Data Sharing Framework Core'
 #target = 'Linux RT x64'
 #build_spec = 'Data Sharing Framework Core'
 
-[[build.steps]]
-name = 'Data Sharing Framework Custom Device Configuration - Windows'
-type = 'lvBuildSpec'
-project = '{CD_windows}'
-target = 'My Computer'
-build_spec = 'Configuration Release'
-dependency_target = 'Windows'
-
-[[build.steps]]
-name = 'Data Sharing Framework Custom Device Engine - Windows'
-type = 'lvBuildSpec'
-project = '{CD_windows}'
-target = 'My Computer'
-build_spec = 'Engine Release'
-dependency_target = 'Windows'
+#[[build.steps]]
+#name = 'Data Sharing Framework Custom Device Configuration - Windows'
+#type = 'lvBuildSpec'
+#project = '{CD_windows}'
+#target = 'My Computer'
+#build_spec = 'Configuration Release'
+#dependency_target = 'Windows'
 
 #[[build.steps]]
-#name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
+#name = 'Data Sharing Framework Custom Device Engine - Windows'
 #type = 'lvBuildSpec'
-#project = '{CD_pharlap}'
-#target = 'RT PXI Target'
+#project = '{CD_windows}'
+#target = 'My Computer'
 #build_spec = 'Engine Release'
-#dependency_target = 'pharlap\\x86'
+#dependency_target = 'Windows'
+
+[[build.steps]]
+name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
+type = 'lvBuildSpec'
+project = '{CD_pharlap}'
+target = 'RT PXI Target'
+build_spec = 'Engine Release'
+dependency_target = 'PharLap'
 
 #[[build.steps]]
 #name = 'Data Sharing Framework Custom Device Engine - Linux RT arm'

--- a/build.toml
+++ b/build.toml
@@ -37,26 +37,26 @@ path = 'VeriStand\Data Sharing Custom Device\Source\Data Sharing Framework Custo
 #target = 'My Computer'
 #build_spec = 'Data Sharing Framework Core'
 
+#[[build.steps]]
+#name = 'Data Sharing Framework Core - Pharlap x86'
+#type = 'lvBuildSpec'
+#project = '{Core_pharlap}'
+#target = 'Pharlap x86'
+#build_spec = 'Data Sharing Framework Core'
+
 [[build.steps]]
-name = 'Data Sharing Framework Core - Pharlap x86'
+name = 'Data Sharing Framework Core - Linux RT ARM'
 type = 'lvBuildSpec'
-project = '{Core_pharlap}'
-target = 'Pharlap x86'
+project = '{Core_linux_arm}'
+target = 'Linux RT ARM'
 build_spec = 'Data Sharing Framework Core'
 
-#[[build.steps]]
-#name = 'Data Sharing Framework Core - Linux RT ARM'
-#type = 'lvBuildSpec'
-#project = '{Core_linux_arm}'
-#target = 'Linux RT ARM'
-#build_spec = 'Data Sharing Framework Core'
-
-#[[build.steps]]
-#name = 'Data Sharing Framework Core - Linux RT x64'
-#type = 'lvBuildSpec'
-#project = '{Core_linux_x64}'
-#target = 'Linux RT x64'
-#build_spec = 'Data Sharing Framework Core'
+[[build.steps]]
+name = 'Data Sharing Framework Core - Linux RT x64'
+type = 'lvBuildSpec'
+project = '{Core_linux_x64}'
+target = 'Linux RT x64'
+build_spec = 'Data Sharing Framework Core'
 
 #[[build.steps]]
 #name = 'Data Sharing Framework Custom Device Configuration - Windows'
@@ -74,29 +74,29 @@ build_spec = 'Data Sharing Framework Core'
 #build_spec = 'Engine Release'
 #dependency_target = 'Windows'
 
+#[[build.steps]]
+#name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
+#type = 'lvBuildSpec'
+#project = '{CD_pharlap}'
+#target = 'RT PXI Target'
+#build_spec = 'Engine Release'
+#dependency_target = 'PharLap'
+
 [[build.steps]]
-name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
+name = 'Data Sharing Framework Custom Device Engine - Linux RT arm'
 type = 'lvBuildSpec'
-project = '{CD_pharlap}'
-target = 'RT PXI Target'
+project = '{CD_linuxRT_arm}'
+target = 'Linux RT ARM'
 build_spec = 'Engine Release'
-dependency_target = 'PharLap'
+dependency_target = 'Linux_32_ARM'
 
-#[[build.steps]]
-#name = 'Data Sharing Framework Custom Device Engine - Linux RT arm'
-#type = 'lvBuildSpec'
-#project = '{CD_linuxRT_arm}'
-#target = 'Linux RT ARM'
-#build_spec = 'Engine Release'
-#dependency_target = 'linux\\arm'
-
-#[[build.steps]]
-#name = 'Data Sharing Framework Custom Device Engine - Linux RT x64'
-#type = 'lvBuildSpec'
-#project = '{CD_linuxRT_x64}'
-#target = 'Linux RT x64'
-#build_spec = 'Engine Release'
-#dependency_target = 'linux\\x64'
+[[build.steps]]
+name = 'Data Sharing Framework Custom Device Engine - Linux RT x64'
+type = 'lvBuildSpec'
+project = '{CD_linuxRT_x64}'
+target = 'Linux RT x64'
+build_spec = 'Engine Release'
+dependency_target = 'Linux_x64'
 
 [package]
 type = 'nipkg'

--- a/build.toml
+++ b/build.toml
@@ -72,7 +72,7 @@ type = 'lvBuildSpec'
 project = '{CD_windows}'
 target = 'My Computer'
 build_spec = 'Engine Release'
-dependency_target = 'win\\x86'
+dependency_target = 'Windows'
 
 #[[build.steps]]
 #name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'

--- a/build.toml
+++ b/build.toml
@@ -37,26 +37,26 @@ project = '{Core_windows}'
 target = 'My Computer'
 build_spec = 'Data Sharing Framework Core'
 
-[[build.steps]]
-name = 'Data Sharing Framework Core - Pharlap x86'
-type = 'lvBuildSpec'
-project = '{Core_pharlap}'
-target = 'Pharlap x86'
-build_spec = 'Data Sharing Framework Core'
+#[[build.steps]]
+#name = 'Data Sharing Framework Core - Pharlap x86'
+#type = 'lvBuildSpec'
+#project = '{Core_pharlap}'
+#target = 'Pharlap x86'
+#build_spec = 'Data Sharing Framework Core'
 
-[[build.steps]]
-name = 'Data Sharing Framework Core - Linux RT ARM'
-type = 'lvBuildSpec'
-project = '{Core_linux_arm}'
-target = 'Linux RT ARM'
-build_spec = 'Data Sharing Framework Core'
+#[[build.steps]]
+#name = 'Data Sharing Framework Core - Linux RT ARM'
+#type = 'lvBuildSpec'
+#project = '{Core_linux_arm}'
+#target = 'Linux RT ARM'
+#build_spec = 'Data Sharing Framework Core'
 
-[[build.steps]]
-name = 'Data Sharing Framework Core - Linux RT x64'
-type = 'lvBuildSpec'
-project = '{Core_linux_x64}'
-target = 'Linux RT x64'
-build_spec = 'Data Sharing Framework Core'
+#[[build.steps]]
+#name = 'Data Sharing Framework Core - Linux RT x64'
+#type = 'lvBuildSpec'
+#project = '{Core_linux_x64}'
+#target = 'Linux RT x64'
+#build_spec = 'Data Sharing Framework Core'
 
 [[build.steps]]
 name = 'Data Sharing Framework Custom Device Configuration - Windows'
@@ -64,7 +64,7 @@ type = 'lvBuildSpec'
 project = '{CD_windows}'
 target = 'My Computer'
 build_spec = 'Configuration Release'
-dependency_target = 'win\\x86'
+dependency_target = 'Windows'
 
 [[build.steps]]
 name = 'Data Sharing Framework Custom Device Engine - Windows'
@@ -74,33 +74,33 @@ target = 'My Computer'
 build_spec = 'Engine Release'
 dependency_target = 'win\\x86'
 
-[[build.steps]]
-name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
-type = 'lvBuildSpec'
-project = '{CD_pharlap}'
-target = 'RT PXI Target'
-build_spec = 'Engine Release'
-dependency_target = 'pharlap\\x86'
+#[[build.steps]]
+#name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
+#type = 'lvBuildSpec'
+#project = '{CD_pharlap}'
+#target = 'RT PXI Target'
+#build_spec = 'Engine Release'
+#dependency_target = 'pharlap\\x86'
 
-[[build.steps]]
-name = 'Data Sharing Framework Custom Device Engine - Linux RT arm'
-type = 'lvBuildSpec'
-project = '{CD_linuxRT_arm}'
-target = 'Linux RT ARM'
-build_spec = 'Engine Release'
-dependency_target = 'linux\\arm'
+#[[build.steps]]
+#name = 'Data Sharing Framework Custom Device Engine - Linux RT arm'
+#type = 'lvBuildSpec'
+#project = '{CD_linuxRT_arm}'
+#target = 'Linux RT ARM'
+#build_spec = 'Engine Release'
+#dependency_target = 'linux\\arm'
 
-[[build.steps]]
-name = 'Data Sharing Framework Custom Device Engine - Linux RT x64'
-type = 'lvBuildSpec'
-project = '{CD_linuxRT_x64}'
-target = 'Linux RT x64'
-build_spec = 'Engine Release'
-dependency_target = 'linux\\x64'
+#[[build.steps]]
+#name = 'Data Sharing Framework Custom Device Engine - Linux RT x64'
+#type = 'lvBuildSpec'
+#project = '{CD_linuxRT_x64}'
+#target = 'Linux RT x64'
+#build_spec = 'Engine Release'
+#dependency_target = 'linux\\x64'
 
 [package]
 type = 'nipkg'
 payload_dir = 'Built\Custom Device'
-install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Data Sharing Framework'
+install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Data Sharing Framework'
 control_file = 'control_dsf_cd'
 package_output_dir = 'Built'

--- a/build.toml
+++ b/build.toml
@@ -30,19 +30,19 @@ path = 'VeriStand\Data Sharing Custom Device\Source\Data Sharing Framework Custo
 [projects.CD_linuxRT_x64]
 path = 'VeriStand\Data Sharing Custom Device\Source\Data Sharing Framework Custom Device Linux RT x64.lvproj'
 
-#[[build.steps]]
-#name = 'Data Sharing Framework Core - Windows'
-#type = 'lvBuildSpec'
-#project = '{Core_windows}'
-#target = 'My Computer'
-#build_spec = 'Data Sharing Framework Core'
+[[build.steps]]
+name = 'Data Sharing Framework Core - Windows'
+type = 'lvBuildSpec'
+project = '{Core_windows}'
+target = 'My Computer'
+build_spec = 'Data Sharing Framework Core'
 
-#[[build.steps]]
-#name = 'Data Sharing Framework Core - Pharlap x86'
-#type = 'lvBuildSpec'
-#project = '{Core_pharlap}'
-#target = 'Pharlap x86'
-#build_spec = 'Data Sharing Framework Core'
+[[build.steps]]
+name = 'Data Sharing Framework Core - Pharlap x86'
+type = 'lvBuildSpec'
+project = '{Core_pharlap}'
+target = 'Pharlap x86'
+build_spec = 'Data Sharing Framework Core'
 
 [[build.steps]]
 name = 'Data Sharing Framework Core - Linux RT ARM'
@@ -58,29 +58,29 @@ project = '{Core_linux_x64}'
 target = 'Linux RT x64'
 build_spec = 'Data Sharing Framework Core'
 
-#[[build.steps]]
-#name = 'Data Sharing Framework Custom Device Configuration - Windows'
-#type = 'lvBuildSpec'
-#project = '{CD_windows}'
-#target = 'My Computer'
-#build_spec = 'Configuration Release'
-#dependency_target = 'Windows'
+[[build.steps]]
+name = 'Data Sharing Framework Custom Device Configuration - Windows'
+type = 'lvBuildSpec'
+project = '{CD_windows}'
+target = 'My Computer'
+build_spec = 'Configuration Release'
+dependency_target = 'Windows'
 
-#[[build.steps]]
-#name = 'Data Sharing Framework Custom Device Engine - Windows'
-#type = 'lvBuildSpec'
-#project = '{CD_windows}'
-#target = 'My Computer'
-#build_spec = 'Engine Release'
-#dependency_target = 'Windows'
+[[build.steps]]
+name = 'Data Sharing Framework Custom Device Engine - Windows'
+type = 'lvBuildSpec'
+project = '{CD_windows}'
+target = 'My Computer'
+build_spec = 'Engine Release'
+dependency_target = 'Windows'
 
-#[[build.steps]]
-#name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
-#type = 'lvBuildSpec'
-#project = '{CD_pharlap}'
-#target = 'RT PXI Target'
-#build_spec = 'Engine Release'
-#dependency_target = 'PharLap'
+[[build.steps]]
+name = 'Data Sharing Framework Custom Device Engine - Pharlap x86'
+type = 'lvBuildSpec'
+project = '{CD_pharlap}'
+target = 'RT PXI Target'
+build_spec = 'Engine Release'
+dependency_target = 'PharLap'
 
 [[build.steps]]
 name = 'Data Sharing Framework Custom Device Engine - Linux RT arm'


### PR DESCRIPTION
Code was not linking correctly because the export folder structure had changed.

This PR adjusts the export file structure to match the exports previously tested and shipped.
win/x86 --> Windows
pharlap/x86 --> PharLap
linux/arm --> Linux_32_ARM
linux/x64 --> Linux_x64
Configuration library and xml promoted such that they no longer appear under a target folder