### PR TITLE
Change Windows build specifications to correctly link dependencies

### DIFF
--- a/VeriStand/Data Sharing Custom Device/Source/Custom Device Data Sharing Framework.xml
+++ b/VeriStand/Data Sharing Custom Device/Source/Custom Device Data Sharing Framework.xml
@@ -13,7 +13,7 @@
     <Type>Action</Type>
     <Item2Launch>
       <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Initialization VI.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Initialization VI.vi</Path>
     </Item2Launch>
   </InitializationVI>
   <CustomDeviceVI>
@@ -74,19 +74,19 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Framework Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Framework Page.vi</Path>
       </Item2Launch>
 	  <ActionVIOnLoad>
 		<Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\ActionVIOnLoad.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\ActionVIOnLoad.vi</Path>
 	  </ActionVIOnLoad>
 	  <ActionVIOnSave>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\ActionVIOnSave.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\ActionVIOnSave.vi</Path>
       </ActionVIOnSave>
 	  <ActionVIOnDownload>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\ActionVIOnDownload.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\ActionVIOnDownload.vi</Path>
       </ActionVIOnDownload>
     </Page>
     <Page>
@@ -101,7 +101,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Plugin Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Plugin Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -116,7 +116,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Thread Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Thread Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -131,7 +131,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Group Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Group Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -146,7 +146,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Transfer Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Transfer Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -161,7 +161,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Data Channel Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Data Channel Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -176,7 +176,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Status Section Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Status Section Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -191,7 +191,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Status Channel Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Status Channel Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -206,7 +206,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Performance Channel Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Performance Channel Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -221,7 +221,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Monitoring Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Monitoring Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -236,7 +236,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Data Section Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Data Section Page.vi</Path>
       </Item2Launch>
     </Page>
   </Pages>

--- a/VeriStand/Data Sharing Custom Device/Source/Custom Device Data Sharing Framework.xml
+++ b/VeriStand/Data Sharing Custom Device/Source/Custom Device Data Sharing Framework.xml
@@ -13,7 +13,7 @@
     <Type>Action</Type>
     <Item2Launch>
       <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Initialization VI.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Initialization VI.vi</Path>
     </Item2Launch>
   </InitializationVI>
   <CustomDeviceVI>
@@ -74,19 +74,19 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Framework Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Framework Page.vi</Path>
       </Item2Launch>
 	  <ActionVIOnLoad>
 		<Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\ActionVIOnLoad.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\ActionVIOnLoad.vi</Path>
 	  </ActionVIOnLoad>
 	  <ActionVIOnSave>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\ActionVIOnSave.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\ActionVIOnSave.vi</Path>
       </ActionVIOnSave>
 	  <ActionVIOnDownload>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\ActionVIOnDownload.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\ActionVIOnDownload.vi</Path>
       </ActionVIOnDownload>
     </Page>
     <Page>
@@ -101,7 +101,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Plugin Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Plugin Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -116,7 +116,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Thread Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Thread Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -131,7 +131,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Group Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Group Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -146,7 +146,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Transfer Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Transfer Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -161,7 +161,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Data Channel Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Data Channel Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -176,7 +176,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Status Section Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Status Section Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -191,7 +191,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Status Channel Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Status Channel Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -206,7 +206,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Performance Channel Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Performance Channel Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -221,7 +221,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Monitoring Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Monitoring Page.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -236,7 +236,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Data Sharing Framework\DSF Configuration.llb\Data Section Page.vi</Path>
+		<Path>Custom Devices\Data Sharing Framework\Windows\DSF Configuration.llb\Data Section Page.vi</Path>
       </Item2Launch>
     </Page>
   </Pages>

--- a/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device.lvproj
+++ b/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device.lvproj
@@ -397,23 +397,22 @@
 			<Item Name="Configuration Release" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{F7E936A1-C50B-4217-AC2B-A4DA3629CD4B}</Property>
 				<Property Name="Bld_buildSpecName" Type="Str">Configuration Release</Property>
-				<Property Name="Bld_excludeDependentPPLs" Type="Bool">true</Property>
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device/Windows</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{E8035317-FDF9-4FC1-9EF0-1450E8CAE472}</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/Windows</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/Windows</Property>
 				<Property Name="Destination[2].destName" Type="Str">DSF Configuration LLB</Property>
-				<Property Name="Destination[2].path" Type="Path">../Built/Custom Device/DSF Configuration.llb</Property>
+				<Property Name="Destination[2].path" Type="Path">../Built/Custom Device/Windows/DSF Configuration.llb</Property>
 				<Property Name="Destination[2].type" Type="Str">LLB</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
-				<Property Name="Source[0].itemID" Type="Str">{FF5D026F-FC30-4B37-8D3F-3B389BA402E2}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{2D9F8C6E-01AB-472E-BD74-F72528B770B8}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Custom Device Data Sharing Framework.xml</Property>

--- a/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device.lvproj
+++ b/VeriStand/Data Sharing Custom Device/Source/Data Sharing Framework Custom Device.lvproj
@@ -399,20 +399,20 @@
 				<Property Name="Bld_buildSpecName" Type="Str">Configuration Release</Property>
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device/Windows</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/Custom Device</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{E8035317-FDF9-4FC1-9EF0-1450E8CAE472}</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device/Windows</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/Custom Device</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
 				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/Windows</Property>
 				<Property Name="Destination[2].destName" Type="Str">DSF Configuration LLB</Property>
-				<Property Name="Destination[2].path" Type="Path">../Built/Custom Device/Windows/DSF Configuration.llb</Property>
+				<Property Name="Destination[2].path" Type="Path">../Built/Custom Device/DSF Configuration.llb</Property>
 				<Property Name="Destination[2].type" Type="Str">LLB</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
-				<Property Name="Source[0].itemID" Type="Str">{2D9F8C6E-01AB-472E-BD74-F72528B770B8}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{3A62D1B5-A36C-408F-8FE2-8674EFC13EB7}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Custom Device Data Sharing Framework.xml</Property>
@@ -466,7 +466,7 @@
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
 				<Property Name="Destination[1].path" Type="Path">../Built/Custom Device/Windows</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{FF5D026F-FC30-4B37-8D3F-3B389BA402E2}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{3A62D1B5-A36C-408F-8FE2-8674EFC13EB7}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/DSF Engine.lvlib/RT Driver VI.vi</Property>


### PR DESCRIPTION
### What does this Pull Request accomplish?

The Windows Engine Release and Configuration Release build specifications were creating builds that were not correctly linked to the dependent .lvlibp. This changes the exclusions in the build specs to include the .lvlibp files and link correctly against them.

### Why should this Pull Request be merged?

This enables the built files to correctly load in System Explorer and deploy to Windows.

### What testing has been done?

Manually built the build specs and tested the linked files in the output.