### PR TITLE
Remove NI prefix from VeriStand in display name

### DIFF
--- a/control_dsf_cd
+++ b/control_dsf_cd
@@ -11,5 +11,5 @@ XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
-XB-DisplayName: NI Data Sharing Framework Custom Device for NI VeriStand {veristand_version}
+XB-DisplayName: NI Data Sharing Framework Custom Device for VeriStand {veristand_version}
 Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove the "NI" prefix from "NI VeriStand" in the package display name.

### Why should this Pull Request be merged?

This matches the rest of the custom device packages.

### What testing has been done?

None, trivial change.
