### PR TITLE
Parent custom device under NI in menu

### DIFF
--- a/VeriStand/Data Sharing Custom Device/Source/Custom Device Data Sharing Framework.xml
+++ b/VeriStand/Data Sharing Custom Device/Source/Custom Device Data Sharing Framework.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 <XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
   <AddMenu>
-    <eng>Data Sharing Framework</eng>
-    <loc>Data Sharing Framework</loc>
+    <eng>NI::Data Sharing Framework</eng>
+    <loc>NI::Data Sharing Framework</loc>
   </AddMenu>
   <Version>1.0.0</Version>
   <Type>Inline HW Interface</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the custom device appear under the "NI" menu item.

### Why should this Pull Request be merged?

Branding update.

### What testing has been done?

N/A

