### PR TITLE
Stop building 2019

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('vs-build-tools') _
 
 def lvVersions = [
-  32 : ['2019', '2020'],
+  32 : ['2020'],
   64 : ['2021']
 ]
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Stops the custom device build for LV/VS 2019.

### Why should this Pull Request be merged?

We are dropping 2019 this release anyway, but another PR was made in LV 2020, so the 2019 build will always fail now.

### What testing has been done?

N/A
