### PR TITLE
Clear compile cache before building

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -21,6 +21,10 @@ path = 'Source\Custom Device\Data Sharing Framework Custom Device Linux RT x64.l
 [projects.ScriptingExamples_windows]
 path = 'Source\Scripting Examples\Data Sharing Framework Scripting.lvproj'
 
+[[codegen.steps]]
+name = 'Clear Compile Cache'
+type = 'lvClearCache'
+
 [[build.steps]]
 name = 'Data Sharing Framework Core - Windows'
 type = 'lvBuildSpec'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Creates a codegen step to delete the compiled object cache before building this custom device.

### Why should this Pull Request be merged?

There is currently an issue in LabVIEW 2023 where this custom device will build once, but not subsequent times without clearing the compile cache. This change allows us to work around that.

### What testing has been done?

Ran two consecutive builds of the dev branch and confirmed both completed successfully.
