### PR TITLE
Require a version of the `ni-veristand-20xx-custom-device-labview-support-common` package which provides 2023 support

### DIFF
--- a/control_dsf_scripting
+++ b/control_dsf_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Data Sharing Framework LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
 Recommends: ni-data-sharing-framework-veristand-{veristand_version}-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Require a version of the `ni-veristand-20xx-custom-device-labview-support-common` package which provides 2023 support.

### Why should this Pull Request be merged?

This is needed to fix the feed build.

### What testing has been done?

N/A
