### PR TITLE
Loosen ni-data-sharing-framework-plugins-veristand-20xx-support requirement

### DIFF
--- a/control_dsf_examples
+++ b/control_dsf_examples
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Data Sharing Framework LabVIEW Examples for VeriStand {veristand_version}
-Depends: ni-data-sharing-framework-veristand-{veristand_version}-labview-support (>= {display_version}), ni-data-sharing-framework-plugins-veristand-{veristand_version}-support (>= {display_version})
+Depends: ni-data-sharing-framework-veristand-{veristand_version}-labview-support (>= {display_version}), ni-data-sharing-framework-plugins-veristand-{veristand_version}-support (>= 21.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allow 21.0.0 or 21.3.0 plugins when installing the examples package.

### Why should this Pull Request be merged?

Examples are currently failing to install for 21.3.1, as no plugins package exists with this version.

### What testing has been done?

N/A
