### PR TITLE
Revert "Clear compile cache before building"

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -21,10 +21,6 @@ path = 'Source\Custom Device\Data Sharing Framework Custom Device Linux RT x64.l
 [projects.ScriptingExamples_windows]
 path = 'Source\Scripting Examples\Data Sharing Framework Scripting.lvproj'
 
-[[codegen.steps]]
-name = 'Clear Compile Cache'
-type = 'lvClearCache'
-
 [[build.steps]]
 name = 'Data Sharing Framework Core - Windows'
 type = 'lvBuildSpec'


### PR DESCRIPTION
Reverts ni/niveristand-data-sharing-framework-custom-device#61.

This should no longer be needed.