### PR TITLE
Remove CD LLBs from Always Included files in Scripting API build

### DIFF
--- a/Source/Custom Device/Data Sharing Framework Custom Device.lvproj
+++ b/Source/Custom Device/Data Sharing Framework Custom Device.lvproj
@@ -916,7 +916,7 @@
 				<Property Name="Destination[2].destName" Type="Str">Errors</Property>
 				<Property Name="Destination[2].path" Type="Path">../Built/Errors</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
-				<Property Name="Source[0].itemID" Type="Str">{EBA6D1CE-4CE0-47B5-B062-89A527CA7BBF}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{F48A4247-E3FD-4072-9239-69D1EDCF5263}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Scripting API/Data Sharing Framework Custom Device Scripting.lvlib</Property>
@@ -926,7 +926,6 @@
 				<Property Name="Source[2].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[2].itemID" Type="Ref">/My Computer/DSF Shared.lvlib</Property>
 				<Property Name="Source[2].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[2].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[2].type" Type="Str">Library</Property>
 				<Property Name="Source[3].itemID" Type="Ref">/My Computer/DSF Shared.lvlib/Properties/Get Configuration Version.vi</Property>
 				<Property Name="Source[3].newName" Type="Str">shared_Get Configuration Version.vi</Property>
@@ -934,12 +933,10 @@
 				<Property Name="Source[4].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[4].itemID" Type="Ref">/My Computer/DSF System Explorer.lvlib</Property>
 				<Property Name="Source[4].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[4].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[4].type" Type="Str">Library</Property>
 				<Property Name="Source[5].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[5].itemID" Type="Ref">/My Computer/DSF Engine.lvlib</Property>
 				<Property Name="Source[5].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[5].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[5].type" Type="Str">Library</Property>
 				<Property Name="Source[6].destinationIndex" Type="Int">2</Property>
 				<Property Name="Source[6].itemID" Type="Ref">/My Computer/Documents/DSF-errors.txt</Property>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove CD LLBs from Always Included files in Scripting API build

### Why should this Pull Request be merged?

Fixes Scripting API build [failures](https://nijenkins/blue/organizations/jenkins/NI%2Fniveristand-data-sharing-framework-custom-device/detail/release%2F23.0/10/pipeline/) in 2023.

### What testing has been done?

Manually build the scripting API in 2023. The list of files output is much smaller, but I don't think anyone needs RT Driver.vi to script the CD...