### PR TITLE
shorten payloads

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,16 +70,16 @@ stages:
         - controlFileName: 'control_dsf_cd'
           payloadMaps:
             - installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\Data Sharing Framework'
-              payloadLocation: 'Source\Built\Custom Device'
+              payloadLocation: 'Custom Device'
             - installLocation: 'ni-paths-NISHAREDDIR$(nipkgx64suffix)\Errors\English'
-              payloadLocation: 'Source\Built\Errors'
+              payloadLocation: 'Errors'
 
         - controlFileName: 'control_dsf_scripting'
           payloadMaps:
             - installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\Data Sharing Framework'
-              payloadLocation: 'Source\Built\Scripting API'
+              payloadLocation: 'Scripting API'
 
         - controlFileName: 'control_dsf_examples'
           payloadMaps:
             - installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\examples\NI VeriStand Custom Devices\Data Sharing Framework'
-              payloadLocation: 'Source\Built\Scripting Examples'
+              payloadLocation: 'Scripting Examples'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Now that we are using payloads from nirvana archives, we do not need to include the build output path.

### Why should this Pull Request be merged?

If this is not included, we will not have any payloads in the builds

### What testing has been done?

PR Build output
