### PR TITLE
Bump release version to 23.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
           target: 'Linux RT x64'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '23.5.0'
+      releaseVersion: '23.8.0'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\data_sharing_framework_CD'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump release version to 23.8

### Why should this Pull Request be merged?

We will release this custom device for 2023 Q4, so the version needs to be 23.8

### What testing has been done?

None
