### PR TITLE
Adding localization text in niveristand data sharing framework custom device control page in six different languages

### DIFF
--- a/control_dsf_cd
+++ b/control_dsf_cd
@@ -13,13 +13,13 @@ Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Data Sharing Framework Custom Device for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)
-Description-zh-CN:为NI VeriStand {veristand_version}提供NI Data Sharing Framework插件的支持。
-XB-DisplayName-zh-CN: NI Data Sharing Framework Plugins for VeriStand {veristand_version}
-Description-de:  Stellt Unterstützung für NI Data Sharing Framework Plugins für NI VeriStand {veristand_version} bereit
-XB-DisplayName-de: NI Data Sharing Framework Plugins für VeriStand {veristand_version}
-Description-fr: Fournit le support pour les plug-ins NI Data Sharing Framework pour NI VeriStand {veristand_version}
-XB-DisplayName-fr: NI Data Sharing Framework - Plugins pour VeriStand {veristand_version}
-Description-ja: NI VeriStand {veristand_version}用 NI Data Sharing Framework Pluginsサポートを提供します。
-XB-DisplayName-ja: NI Data Sharing Framework Plugins - VeriStand  {veristand_version}用
-Description-ko: NI VeriStand {veristand_version}을(를) 위한 NI Data Sharing Framework Plugins의 지원을 제공합니다.
-XB-DisplayName-ko: NI Data Sharing Framework Plugins - VeriStand {veristand_version} 지원
+Description-zh-CN: 为NI VeriStand {veristand_version}提供 NI Data Sharing Framework Custom Device支持
+XB-DisplayName-zh-CN: NI Data Sharing Framework Custom Device for VeriStand {veristand_version}
+Description-de: Stellt Unterstützung für NI Data Sharing Framework Custom Device für NI VeriStand {veristand_version} bereit.
+XB-DisplayName-de: NI Data Sharing Framework Custom Device für VeriStand {veristand_version}
+Description-fr: Fournit le support pour le périphérique personnalisé NI Data Sharing Framework pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI Data Sharing Framework Custom Device for VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用 NI データ共有フレームワークカスタムデバイスサポートを提供します。 
+XB-DisplayName-ja: NI NI Data Sharing Framework Custom Device - VeriStand {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 NI Data Sharing Framework Custom Device의 지원을 제공합니다.
+XB-DisplayName-ko: NI Data Sharing Framework Custom Device - VeriStand {veristand_version} 지원

--- a/control_dsf_cd
+++ b/control_dsf_cd
@@ -13,3 +13,13 @@ Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Data Sharing Framework Custom Device for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)
+Description-zh-CN:为NI VeriStand {veristand_version}提供NI Data Sharing Framework插件的支持。
+XB-DisplayName-zh-CN: NI Data Sharing Framework Plugins for VeriStand {veristand_version}
+Description-de:  Stellt Unterstützung für NI Data Sharing Framework Plugins für NI VeriStand {veristand_version} bereit
+XB-DisplayName-de: NI Data Sharing Framework Plugins für VeriStand {veristand_version}
+Description-fr: Fournit le support pour les plug-ins NI Data Sharing Framework pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI Data Sharing Framework - Plugins pour VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用 NI Data Sharing Framework Pluginsサポートを提供します。
+XB-DisplayName-ja: NI Data Sharing Framework Plugins - VeriStand  {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 NI Data Sharing Framework Plugins의 지원을 제공합니다.
+XB-DisplayName-ko: NI Data Sharing Framework Plugins - VeriStand {veristand_version} 지원


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-data-sharing-framework-custom-device control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress
