### PR TITLE
Bump release version to 24.5.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
           target: 'Linux RT x64'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '24.5.0'
+      releaseVersion: '24.5.1'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\data_sharing_framework_CD'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Bumps version of custom device in main

### Why should this Pull Request be merged?
We need a 24.5.1 release.

### What testing has been done?
PR build