### PR TITLE
Fix dependency version requirement for LabVIEW support

### DIFF
--- a/control_dsf_scripting
+++ b/control_dsf_scripting
@@ -12,7 +12,7 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Data Sharing Framework LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 25.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= {labview_short_version}.0.0)
 Recommends: ni-data-sharing-framework-veristand-{veristand_version}-support (>= {display_version})
 Description-zh-CN:为NI VeriStand {veristand_version}提供 NI Data Sharing Framework Custom Device的LabVIEW支持
 XB-DisplayName-zh-CN: NI Data Sharing Framework LabVIEW Support for VeriStand {veristand_version}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixed the LabVIEW-Support-Common dependency version to labview release version to avoid mismatch in the VeriStand Custom Device Installer Metadata Summary and feeds.

### Why should this Pull Request be merged?

To avoid Publishing Issues for future release.

### What testing has been done?

PR Build
